### PR TITLE
added override option for config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "license": "BSD",
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "*",
+    "optimist": "~0.6.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -4,7 +4,16 @@ var http = require('http'),
     Cache = require('./lib/cache2.js'),
     Package = require('./lib/package.js'),
     Resource = require('./lib/resource.js'),
-    config = require('./config.js');
+    config = require('./config.js'),
+    fs = require('fs'),
+    argv = require('optimist')
+      .default('config', config)
+      .alias('c', 'config')
+      .argv;
+
+if (argv.config){
+  config = require(argv.config);
+}
 
 Resource.configure({
   cache: new Cache({ path: config.cacheDirectory }),


### PR DESCRIPTION
Currently there is no easy way to have a module which depends on npm_lazy and have it run with a different configuration. 

With this change you can run npm_lazy by doing this:
- create package.json
- run npm install --save-dev
- create custom configuration in someconfig.js
- start npm_lazy with node server --config=someconfig.js

I did this by using the optimist module for easy command line parsing, it might not be to your liking but this could be done without any additional dependencies too.
