### PR TITLE
bug-fix: use the remoteUrl from config in the api

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -4,9 +4,17 @@ var fs = require('fs'),
     Router = require('mixu_minimal').Router,
 
     Package = require('./package.js'),
-    Resource = require('./resource.js');
+    Resource = require('./resource.js'),
+
+    remoteUrl = 'http://registry.npmjs.org/';
 
 var api = new Router();
+
+api.configure = function(config) {
+  if(typeof config.remoteUrl !== 'undefined') {
+    remoteUrl = config.remoteUrl;
+  }
+};
 
 // GET /package
 api.get(new RegExp('^/([^/]+)$'), function(req, res, match) {
@@ -26,7 +34,7 @@ api.get(new RegExp('^/([^/]+)$'), function(req, res, match) {
 api.get(new RegExp('^/(.+)/-/(.+)$'), function(req, res, match) {
   var name = match[1],
       file = match[2],
-      uri = 'http://registry.npmjs.org/' + name + '/-/' + file;
+      uri = remoteUrl + name + '/-/' + file;
   // direct cache access - this is a file get, not a metadata get
   console.log('cache get', uri);
 

--- a/server.js
+++ b/server.js
@@ -15,10 +15,13 @@ function start(config) {
     rejectUnauthorized: config.rejectUnauthorized
   });
 
-  Package.configure({
+  var packageConfig = {
     externalUrl: config.externalUrl,
     remoteUrl: config.remoteUrl
-  });
+  };
+
+  Package.configure(packageConfig);
+  api.configure(packageConfig);
 
   var server = http.createServer();
 


### PR DESCRIPTION
`api.js` has the global registry hard-coded. This PR uses the `remoteUrl` from the config instead.
