### PR TITLE
Check for package corruption.

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -111,8 +111,27 @@ Resource.prototype.getReadablePath = function(onDone) {
     if (self.type == 'tar' && self.exists()) {
       self.emit('fetch-cached');
       // is this a tarfile and is it in the index?
-      // yes: return readable stream
-      return onDone(null, self.exists());
+      // yes: check sha1 hash
+      var Package = require('./package.js');
+      return Package.getIndex(self.getPackageName(), function(err, data) {
+        if (err) {
+          return onDone(err, null);
+        }
+        expectedHash = verify.getSha(self.basename, data);
+        verify.check(self.exists(), function(err, actualHash) {
+          if (err) {
+            return onDone(err, null);
+          }
+          if (actualHash === expectedHash) {
+            return onDone(null, self.exists()); // return readable stream if file is good
+          }
+
+          // otherwise, cache is corrupted somehow, so bust cache and retry
+          console.log('Cached package is corrupt. Refetching ' + self.url);
+          Cache.junk(self.url);
+          self.getReadablePath(onDone);
+        });
+      });
     }
   }
 


### PR DESCRIPTION
Fixes #26 by checking the sha1 hash every time a package is requested. Might be a bit heavy, but fixes the problem.
