### PR TITLE
Add proxy support

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -298,6 +298,7 @@ Resource.removeFile = function(filepath) {
 };
 
 Resource.prototype._fetchTask = function(onDone) {
+  var match;
   var url = coreUrl.parse(this.url),
       opts = {
         method: 'GET',
@@ -307,6 +308,29 @@ Resource.prototype._fetchTask = function(onDone) {
         protocol: url.protocol
       }, req;
 
+	 debugger;
+	  
+   var httpInstance = (url.protocol == 'https:' ? https : http);
+	  
+  if (process.env.http_proxy != null) {
+    
+	match = process.env.http_proxy.match(/^(http:\/\/)?([^:\/]+)(:([0-9]+))?/i);
+	
+    if (match) {
+      opts = {
+        host: match[2],
+        port: (match[4] != null ? match[4] : 80),
+        path: url.path,
+		headers: {
+			Host: url.hostname
+		}
+      };
+	  
+	  // Set to the http proxy
+	  httpInstance = http;
+    }
+  }
+	  
   if(!rejectUnauthorized && url.protocol == 'https:') {
     opts.rejectUnauthorized = false;
     opts.agent = new https.Agent(opts);
@@ -314,7 +338,7 @@ Resource.prototype._fetchTask = function(onDone) {
 
   logger.log('[GET] ' + this.url);
 
-  req = (url.protocol == 'https:' ? https : http).request(opts, function(res){
+  req = httpInstance.get(opts, function(res){
     if (res.statusCode != 200) {
       return onDone(new Error('Request failed with code ' + res.statusCode));
     }


### PR DESCRIPTION
Add proxy support (http only) via a regular http_proxy environment variable

Works fine under Windows and Linux
