### PR TITLE
fixed random corrupt cached package errors

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -124,7 +124,7 @@ Resource.prototype.getReadablePath = function(onDone) {
         if (err) {
           return onDone(err, null, null);
         }
-        expectedHash = verify.getSha(self.basename, data);
+        var expectedHash = verify.getSha(self.basename, data);
         verify.check(self.exists(), function(err, actualHash) {
           if (err) {
             return onDone(err, null, null);


### PR DESCRIPTION
I encountered random corrupt cached package errors while trying to use npm lazy as cache in the company network to survive outtages of registry.npmjs.org. Here is some log output showing that expectedHash is a global variable and overwritten by concurrent get requests:

app debug cache get http://registry.npmjs.org/karma/-/karma-0.12.23.tgz
app debug [OK] Reusing cached result for http://registry.npmjs.org/karma
Set expectedHash 2a01041019234f76f59b8c7c2128f06c839fe8c3 for karma-0.12.23.tgz
app debug cache get http://registry.npmjs.org/karma-ox-ui/-/karma-ox-ui-0.0.2.tgz
app debug [OK] Reusing cached result for http://registry.npmjs.org/karma-ox-ui
Set expectedHash e544c45f273d8384eee72efbee7ae9bf4d52c38b for karma-ox-ui-0.0.2.tgz
app debug [304] http://registry.npmjs.org/sinon
app debug [304] http://registry.npmjs.org/appserver
app debug cache get http://registry.npmjs.org/mocha/-/mocha-1.21.4.tgz
app debug [OK] Reusing cached result for http://registry.npmjs.org/mocha
Set expectedHash e77d69c3773ba3e2b4fe6b628c28b5dd43880adc for mocha-1.21.4.tgz
Cached package is corrupt. Refetching http://registry.npmjs.org/karma/-/karma-0.12.23.tgz expectHash=e77d69c3773ba3e2b4fe6b628c28b5dd43880adc actualHash=2a01041019234f76f59b8c7c2128f06c839fe8c3 karma-0.12.23.tgz

So expectedHash must be a local variable to not be overwritten by concurrent get requests.
