### PR TITLE
private package support: pass 'authorization' header through on index/tar gets

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -24,8 +24,9 @@ api.configure = function(config) {
 // GET /package
 api.get(new RegExp('^/([^/]+)$'), function(req, res, match) {
   var name = match[1];
+  var auth = req.headers.authorization;
 
-  Package.getIndex(name, function(err, fullpath, etag) {
+  Package.getIndex(name, auth, function(err, fullpath, etag) {
     if (err) {
       res.statusCode = err.statusCode || 500;
       logger.error('[' + res.statusCode + '] Error: ', err);
@@ -64,8 +65,9 @@ api.get(new RegExp('^/(@.+)/-/([^/]+)$'), function(req, res, match) {
 function downloadTar(req, res, uri) {
   // direct cache access - this is a file get, not a metadata get
   logger.log('cache get', uri);
+  var auth = req.headers.authorization;
 
-  Resource.get(uri)
+  Resource.get(uri, auth)
           .getReadablePath(function(err, fullpath, etag) {
             if (err) {
               res.statusCode = err.statusCode || 500;

--- a/lib/package.js
+++ b/lib/package.js
@@ -76,10 +76,10 @@ Package.proxy = function(req, res, message) {
   // req.pipe(process.stdout);
 };
 
-Package.getIndex = function(pname, onDone) {
+Package.getIndex = function(pname, auth, onDone) {
   // package index
   var uri = remoteUrl + pname,
-      r = Resource.get(uri);
+      r = Resource.get(uri, auth);
 
   r.on('fetch-error', function(err, current, max) {
     logger.log('Fetch failed (' + current + '/' + max + '): ' + uri, err);

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -32,8 +32,9 @@ var resourceCache = {},
 //
 // easier than trying to juggle these responsibilities in the caching logic
 
-function Resource(url) {
+function Resource(url, auth) {
   this.url = url;
+  this.auth = auth;
 
   this.retries = 0;
 
@@ -124,7 +125,7 @@ Resource.prototype.getReadablePath = function(onDone) {
       // is this a tarfile and is it in the index?
       // yes: check sha1 hash
       var Package = require('./package.js');
-      return Package.getIndex(self.getPackageName(), function(err, data) {
+      return Package.getIndex(self.getPackageName(), self.auth, function(err, data) {
         if (err) {
           return onDone(err, null, null);
         }
@@ -309,7 +310,7 @@ Resource.prototype._afterFetch = function(err, readableStream) {
         // read the expected checksum
         var Package = require('./package.js');
 
-        Package.getIndex(self.getPackageName(), function(err, data) {
+        Package.getIndex(self.getPackageName(), self.auth, function(err, data) {
           if (err) {
             self.err = err;
             return guard.release(self.url);
@@ -367,7 +368,8 @@ Resource.prototype._fetchTask = function(onDone) {
   var self = this;
   var opts = {
         url: coreUrl.parse(this.url),
-        method: 'GET'
+        method: 'GET',
+        headers: {}
       },
       req,
       isHttps = (opts.url.protocol == 'https:'),
@@ -382,8 +384,11 @@ Resource.prototype._fetchTask = function(onDone) {
   }
 
   if (self.lookup() && self.lookup().etag) {
-    opts.headers = opts.headers || {};
     opts.headers['if-none-match'] = self.lookup().etag;
+  }
+
+  if (self.auth) {
+    opts.headers['authorization'] = self.auth;
   }
 
   logger.log('[GET] ' + this.url);
@@ -400,9 +405,9 @@ Resource.prototype._fetchTask = function(onDone) {
 
 // one instance of a resource per url
 
-Resource.get = function(url) {
+Resource.get = function(url, auth) {
   if (!resourceCache[url]) {
-    resourceCache[url] = new Resource(url);
+    resourceCache[url] = new Resource(url, auth);
   }
   return resourceCache[url];
 };

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -26,10 +26,11 @@ describe('given a package', function() {
 
   it('can fetch a package index', function(done) {
     this.timeout(10000);
+    var auth = null;
 
     // Note: this goes out the the real reg!
 
-    Package.getIndex('foo', function(err, actual) {
+    Package.getIndex('foo', auth, function(err, actual) {
       var expected = JSON.parse(
         fs.readFileSync(__dirname + '/db/foo.json')
         .toString().replace('http://registry.npmjs.com/foo', 'http://localhost:8080/foo')


### PR DESCRIPTION
Fixes #60

I recently started using npm private packages instead of `sinopia`, and I was sad that I had to give up offline `npm install`. Found this package, but realized that it didn't support private packages!

This is a very simple change, since npm uses a bearer token. We pipe that through to downstream requests to the npm registry. Because `npm_lazy` already proxies other requests, you can do an `npm login` like normal. :0)

Thanks for this package, by the way. Offline installs are important!