### PR TITLE
Added handling for cases where the remoteUrl is more complex

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -8,6 +8,7 @@ var fs = require('fs'),
     ETag = require('./etag.js'),
 
     remoteUrl = 'http://registry.npmjs.com/',
+    pathPrefix = '';
     logger = console;
 
 var api = new Router();
@@ -19,48 +20,90 @@ api.configure = function(config) {
   if (typeof config.logger !== 'undefined') {
     logger = config.logger;
   }
+  var pathMatcher = new RegExp('^https{0,1}://[^/]*/(.*/)$');
+  if (pathMatcher.test(remoteUrl)) {
+    var match = pathMatcher.exec(remoteUrl);
+    pathPrefix = match[1];
+    api.get(new RegExp('^/' + pathPrefix + '([^/]+)/(-|download)/([^/]+)$'), function (req, res, match) {
+      return handleDownloadRequest(req, res, match);
+    });
+  }
+
+  // GET /package
+  api.get(new RegExp('^/([^/]+)$'), function (req, res, match) {
+    var name = match[1];
+    var auth = req.headers.authorization;
+
+    Package.getIndex(name, auth, function (err, fullpath, etag) {
+      if (err) {
+        res.statusCode = err.statusCode || 500;
+        logger.error('[' + res.statusCode + '] Error: ', err);
+        if (err.content) {
+          res.write(err.content);
+        }
+        res.end();
+        return;
+      }
+
+      if (ETag.handle304(req, res, etag)) {
+        return;
+      }
+
+      res.end(JSON.stringify(fullpath));
+    });
+  });
+
+  // GET /package/download/package-version.tgz
+  // GET /package/-/package-version.tgz
+  api.get(new RegExp('^/([^/]+)/(-|download)/([^/]+)$'), function (req, res, match) {
+    return handleDownloadRequest(req, res, match);
+  });
+
+  // GET /@scope/package/-/package-version.tgz
+  api.get(new RegExp('^/(@.+)/-/([^/]+)$'), function (req, res, match) {
+    var name = match[1],
+        file = match[2],
+        uri = remoteUrl + name + '/-/' + file;
+    return downloadTar(req, res, uri);
+  });
+
+  // /-/ or /package/-/ are special
+  api.get(new RegExp('^/-/(.+)$'), Package.proxy);
+  api.get(new RegExp('^/(.+)/-(.*)$'), Package.proxy);
+
+  // GET /package/version
+  api.get(new RegExp('^/([^/]+)/([^/]+)$'), function (req, res, match) {
+    var name = match[1],
+        version = match[2],
+        self = this;
+
+    Package.getVersion(name, version, function (err, fullpath, etag) {
+      if (err) {
+        res.statusCode = err.statusCode || 500;
+        logger.error('[' + res.statusCode + '] Error: ', err);
+        if (err.content) {
+          res.write(err.content);
+        }
+        res.end();
+        return;
+      }
+
+      if (ETag.handle304(req, res, etag)) {
+        return;
+      }
+
+      res.end(JSON.stringify(fullpath));
+    });
+  });
 };
 
-// GET /package
-api.get(new RegExp('^/([^/]+)$'), function(req, res, match) {
-  var name = match[1];
-  var auth = req.headers.authorization;
-
-  Package.getIndex(name, auth, function(err, fullpath, etag) {
-    if (err) {
-      res.statusCode = err.statusCode || 500;
-      logger.error('[' + res.statusCode + '] Error: ', err);
-      if (err.content) {
-        res.write(err.content);
-      }
-      res.end();
-      return;
-    }
-
-    if (ETag.handle304(req, res, etag)) {
-      return;
-    }
-
-    res.end(JSON.stringify(fullpath));
-  });
-});
-
-// GET /package/download/package-version.tgz
-// GET /package/-/package-version.tgz
-api.get(new RegExp('^/([^/]+)/(-|download)/([^/]+)$'), function(req, res, match) {
+function handleDownloadRequest(req, res, match) {
   var name = match[1],
       name2 = match[2],
       file = match[3],
       uri = remoteUrl + name + '/' + name2 + '/' + file;
   return downloadTar(req, res, uri);
-});
-// GET /@scope/package/-/package-version.tgz
-api.get(new RegExp('^/(@.+)/-/([^/]+)$'), function(req, res, match) {
-  var name = match[1],
-      file = match[2],
-      uri = remoteUrl + name + '/-/' + file;
-  return downloadTar(req, res, uri);
-});
+}
 
 function downloadTar(req, res, uri) {
   // direct cache access - this is a file get, not a metadata get
@@ -68,55 +111,25 @@ function downloadTar(req, res, uri) {
   var auth = req.headers.authorization;
 
   Resource.get(uri, auth)
-          .getReadablePath(function(err, fullpath, etag) {
-            if (err) {
-              res.statusCode = err.statusCode || 500;
-              logger.error('[' + res.statusCode + '] Error: ', err);
-              if (err.content) {
-                res.write(err.content);
-              }
-              res.end();
-              return;
-            }
+      .getReadablePath(function(err, fullpath, etag) {
+        if (err) {
+          res.statusCode = err.statusCode || 500;
+          logger.error('[' + res.statusCode + '] Error: ', err);
+          if (err.content) {
+            res.write(err.content);
+          }
+          res.end();
+          return;
+        }
 
-            if (ETag.handle304(req, res, etag)) {
-              return;
-            }
+        if (ETag.handle304(req, res, etag)) {
+          return;
+        }
 
-            res.setHeader('Content-type', 'application/octet-stream');
-            fs.createReadStream(fullpath).pipe(res);
-          });
+        res.setHeader('Content-type', 'application/octet-stream');
+        fs.createReadStream(fullpath).pipe(res);
+      });
 }
-
-// /-/ or /package/-/ are special
-api.get(new RegExp('^/-/(.+)$'), Package.proxy);
-api.get(new RegExp('^/(.+)/-(.*)$'), Package.proxy);
-
-// GET /package/version
-api.get(new RegExp('^/([^/]+)/([^/]+)$'), function(req, res, match) {
-  var name = match[1],
-      version = match[2],
-      self = this;
-
-  Package.getVersion(name, version, function(err, fullpath, etag) {
-    if (err) {
-      res.statusCode = err.statusCode || 500;
-      logger.error('[' + res.statusCode + '] Error: ', err);
-      if (err.content) {
-        res.write(err.content);
-      }
-      res.end();
-      return;
-    }
-
-    if (ETag.handle304(req, res, etag)) {
-      return;
-    }
-
-    res.end(JSON.stringify(fullpath));
-  });
-});
-
 
 
 module.exports = api;

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -98,11 +98,18 @@ Resource.prototype.isUpToDate = function() {
 Resource.prototype.getPackageName = function() {
   var parts = coreUrl.parse(this.url);
   var dirs = path.dirname(parts.pathname).split('/').filter(Boolean);
-  if (dirs[0].charAt(0) === '@') {
-    // https://github.com/npm/npm/blob/2a5977e0c65b244e92d848fcd56f2f80ba8cdf3b/lib/utils/map-to-registry.js#L16
-    return dirs.slice(0, 2).join('%2f');
+  var offset = 0;
+  if (dirs.length > 3) {
+    // Could be package/-/package-version.tgz or package/download/package-version.tgz
+    if (dirs[length-1] == '-' || dirs[length-1] == 'download') {
+      offset = length-3;
+    }
   }
-  return dirs[0];
+  if (dirs[offset].charAt(0) === '@') {
+    // https://github.com/npm/npm/blob/2a5977e0c65b244e92d848fcd56f2f80ba8cdf3b/lib/utils/map-to-registry.js#L16
+    return dirs.slice(offset, offset+2).join('%2f');
+  }
+  return dirs[offset];
 };
 
 // one API

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -100,9 +100,10 @@ Resource.prototype.getPackageName = function() {
   var dirs = path.dirname(parts.pathname).split('/').filter(Boolean);
   var offset = 0;
   if (dirs.length > 3) {
+    var l = dirs.length;
     // Could be package/-/package-version.tgz or package/download/package-version.tgz
-    if (dirs[length-1] == '-' || dirs[length-1] == 'download') {
-      offset = length-3;
+    if (dirs[l-1] == '-' || dirs[l-1] == 'download') {
+      offset = l-2;
     }
   }
   if (dirs[offset].charAt(0) === '@') {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -27,6 +27,8 @@ describe('given a server', function() {
       externalUrl: 'http://localhost:9090'
     });
 
+    api.configure({});
+
     http.createServer(function(req, res) {
       api.route(req, res);
     }).listen(9090, 'localhost', function() {


### PR DESCRIPTION
for example we're using artifactory https://x.y.z/api/npm/npm-repo
because we're hosting jfrog's artifactory behind nginx
