### PR TITLE
Fix for 4 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "minilog": "2.0.x",
     "mixu_minimal": "0.0.1",
     "mkdirp": "0.5.0",
-    "request": "2.36.0",
+    "request": "2.74.0",
     "semver": "1.0",
     "yargs": "1.3.1"
   },


### PR DESCRIPTION
npm_lazy currently has a 2 vulnerable dependency, introducing 5 different types of known vulnerabilities.

This PR fixes one vulnerable dependency and 4 different types of known vulnerabilities. 
* [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
* [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
* [Denial of Service (Event Loop Blocking) vulnerability](https://snyk.io/vuln/npm:qs:20140806-1) in the `qs` dependency.
* [Denial of Service (Memory Exhaustion)](https://snyk.io/vuln/npm:qs:20140806) in the `qs` dependency.

You can see [Snyk test report](https://snyk.io/test/github/mixu/npm_lazy) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix all the vulnerabilities listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade `semver` dependency as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)