### PR TITLE
chore(deps): bump request to 2.88.0 to fix security warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "minilog": "~3.1.0",
     "mixu_minimal": "0.0.1",
     "mkdirp": "~0.5.1",
-    "request": "~2.79.0",
+    "request": "~2.88.0",
     "yargs": "~6.6.0"
   },
   "repository": {


### PR DESCRIPTION
Update request version to 2.88.0 to fix vulnerabilities related to hoek and tunnel-agent.
More info

 * https://nodesecurity.io/advisories/566
 * https://nodesecurity.io/advisories/598