### PR TITLE
fix: missing return value from handle etag

### DIFF
--- a/lib/etag.js
+++ b/lib/etag.js
@@ -4,10 +4,11 @@ var ETag = {
       if (req.headers['if-none-match'] === etag) {
         res.statusCode = 304;
         res.end();
-        return;
+        return true;
       }
       res.setHeader('ETag', etag);
     }
+    return false;
   }
 };
 


### PR DESCRIPTION

The ETag.handle() is expected to return a truth value:
```
            if (ETag.handle304(req, res, etag)) {                               
              return;                                                           
            }       
```
true means handled and ended, false means continue.
